### PR TITLE
Access token should be of type 'Bearer'

### DIFF
--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/auth/Oauth2AccessTokenResponse.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/auth/Oauth2AccessTokenResponse.java
@@ -18,7 +18,7 @@ public class Oauth2AccessTokenResponse {
     private int expiresIn = 3600;
 
     @JsonProperty("token_type")
-    private String tokenType = "JWKS";
+    private String tokenType = "Bearer";
 
     public Oauth2AccessTokenResponse(String idToken) {
         this.idToken = idToken;


### PR DESCRIPTION
This is what is returned from OpenAM (at least for Pesys' configuration)
and Pac4j complains with a validation error if it's set to
anything else.