### PR TITLE
Add mock for LoginService

### DIFF
--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/ApplicationConfig.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/ApplicationConfig.java
@@ -19,6 +19,7 @@ import no.nav.foreldrepenger.vtp.server.api.scenario.TestscenarioTemplateRestTje
 import no.nav.foreldrepenger.vtp.server.rest.IsAliveImpl;
 import no.nav.foreldrepenger.vtp.server.rest.IsReadyImpl;
 import no.nav.foreldrepenger.vtp.server.rest.PeproxyResource;
+import no.nav.foreldrepenger.vtp.server.rest.auth.LoginService;
 import no.nav.foreldrepenger.vtp.server.rest.auth.Oauth2RestService;
 import no.nav.foreldrepenger.vtp.server.rest.auth.PdpRestTjeneste;
 import no.nav.foreldrepenger.vtp.server.rest.auth.STSRestTjeneste;
@@ -117,6 +118,7 @@ public class ApplicationConfig extends Application {
 
         // tekniske ting
         classes.add(Oauth2RestService.class);
+        classes.add(LoginService.class);
         classes.add(AzureAdNAVAnsattService.class);
         classes.add(PeproxyResource.class);
         classes.add(MicrosoftGraphApiMock.class);

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/auth/LoginService.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/auth/LoginService.java
@@ -1,0 +1,110 @@
+package no.nav.foreldrepenger.vtp.server.rest.auth;
+
+import io.swagger.annotations.Api;
+import no.nav.foreldrepenger.vtp.felles.KeyStoreTool;
+import no.nav.foreldrepenger.vtp.testmodell.repo.TestscenarioRepository;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.jose4j.jwk.RsaJsonWebKey;
+import org.jose4j.jws.AlgorithmIdentifiers;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.NumericDate;
+import org.jose4j.lang.JoseException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Api(tags = {"LoginService"})
+@Path("/loginservice")
+public class LoginService {
+    @Context
+    private TestscenarioRepository repo;
+
+    @GET
+    @Path("/login")
+    public Response login(@QueryParam("redirect") String redirect) {
+        List<String> rows = repo.getPersonIndeks().getAlleSøkere().parallelStream()
+                .map(p -> {
+                    String fnr = p.getSøker().getIdent();
+                    String navn = p.getSøker().getFornavn() + " " + p.getSøker().getEtternavn();
+                    return "<a href=\"login-redirect-with-cookie?fnr=" + fnr + "&redirect=" + URLEncoder.encode(redirect, StandardCharsets.UTF_8) + "\">" + navn + "</a> ("+fnr+")<br>";
+                }).collect(Collectors.toList());
+
+        String html = "<!DOCTYPE html>" +
+                "<html>" +
+                "<head>" +
+                "<title>Velg bruker</title>" +
+                "</head>" +
+                "<body>" +
+                "<div style=\"text-align:center;width:100%;\">" +
+                "<h3>Velg bruker:</h3>" +
+                String.join("", rows) +
+                (rows.isEmpty() ? "Det finnes visst ingen personer i VTP akkurat nå. Prøv å <a href=\"/#/\">laste inn et scenario</a>!" : "") +
+                "<form method=\"get\" action=\"login-redirect-with-cookie\">" +
+                "<input type=\"hidden\" name=\"redirect\" value=\""+ StringEscapeUtils.escapeHtml(redirect) +"\">" +
+                "<input name=\"fnr\" placeholder=\"Fyll inn et annet fødselsnummer\" style=\"width: 200px\"><input type=\"submit\"></form>" +
+                "</div>" +
+                "</body>" +
+                "</html>";
+
+        return Response.ok(html, MediaType.TEXT_HTML).build();
+    }
+
+    @GET
+    @Path("/login-redirect-with-cookie")
+    public Response doLogin(@QueryParam("redirect") String redirect, @QueryParam("fnr") String fnr) throws URISyntaxException, JoseException {
+        NumericDate now = NumericDate.now();
+        JwtClaims claims = new JwtClaims();
+
+        claims.setSubject(fnr);
+        claims.setIssuer("https://login.microsoftonline.com/d38f25aa-eab8-4c50-9f28-ebf92c1256f2/v2.0/");
+        claims.setIssuedAt(now);
+        claims.setNotBefore(now);
+        claims.setGeneratedJwtId();
+        claims.setExpirationTime(NumericDate.fromSeconds(now.getValue() + 3600 * 6));
+        claims.setAudience("0090b6e1-ffcc-4c37-bc21-049f7d1f0fe5");
+        claims.setClaim("ver", "1.0");
+        claims.setClaim("acr", "Level4");
+        claims.setNumericDateClaim("auth_time", now);
+        claims.setClaim("nonce", "hardcoded");
+        claims.setClaim("at_hash", "unknown");
+
+        RsaJsonWebKey senderJwk = KeyStoreTool.getJsonWebKey();
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setPayload(claims.toJson());
+        jws.setKeyIdHeaderValue(KeyStoreTool.getJsonWebKey().getKeyId());
+        jws.setAlgorithmHeaderValue("RS256");
+        jws.setKey(senderJwk.getPrivateKey());
+        jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_USING_SHA256);
+
+        String token = jws.getCompactSerialization();
+
+        NewCookie cookie = new NewCookie(
+                "selvbetjening-idtoken",
+                token,
+                "/",
+                null,
+                1,
+                null,
+                -1,
+                null,
+                false,
+                false);
+
+        return Response
+                .temporaryRedirect(new URI(redirect))
+                .cookie(cookie)
+                .build();
+    }
+}

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/azuread/navansatt/AzureAdNAVAnsattService.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/azuread/navansatt/AzureAdNAVAnsattService.java
@@ -43,9 +43,9 @@ public class AzureAdNAVAnsattService {
     @Path("/{tenant}/v2.0/.well-known/openid-configuration")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Azure AD Discovery url", notes = ("Mock impl av Azure AD discovery urlen. "))
-    public Response wellKnown(@SuppressWarnings("unused") @Context HttpServletRequest req, @PathParam("tenant") String tenant) {
+    public Response wellKnown(@SuppressWarnings("unused") @Context HttpServletRequest req, @PathParam("tenant") String tenant, @QueryParam("p") String profile) {
         String baseUrl = getBaseUrl(req);
-        WellKnownResponse wellKnownResponse = new WellKnownResponse(baseUrl, tenant);
+        WellKnownResponse wellKnownResponse = new WellKnownResponse(baseUrl, tenant, profile);
         return Response.ok(wellKnownResponse).build();
     }
 

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/azuread/navansatt/WellKnownResponse.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/azuread/navansatt/WellKnownResponse.java
@@ -31,6 +31,7 @@ userinfo_endpoint: "https://graph.microsoft.com/oidc/userinfo"
 class WellKnownResponse {
     private final String baseUrl;
     private final String tenant;
+    private final String profile;
 
     @JsonProperty("authorization_endpoint")
     public String getAuthorizationEndpoint() {
@@ -83,6 +84,13 @@ class WellKnownResponse {
 
     @JsonProperty("issuer")
     public final String getIssuer() {
+        // Spesialhåndtering for Azure AD B2C.
+        // Veldig rart at Azure AD gjør det sånn, men vi får mocke det realistisk, det sparer oss
+        // for en del problemer andre steder (f.eks. LoginService sin issuer)
+        if (tenant.equals("NAVtestB2C.onmicrosoft.com")) {
+            return "https://login.microsoftonline.com/d38f25aa-eab8-4c50-9f28-ebf92c1256f2/v2.0" + ("B2C_1A_idporten_ver1".equals(profile) ? "/" : "");
+        }
+
         return "https://login.microsoftonline.com/" + tenant + "/v2.0";
     }
 
@@ -128,8 +136,9 @@ class WellKnownResponse {
         return baseUrl + "/rest/AzureGraphAPI/oidc/userinfo";
     }
 
-    WellKnownResponse(String url, String tenant) {
+    WellKnownResponse(String url, String tenant, String profile) {
         this.baseUrl = url;
         this.tenant = tenant;
+        this.profile = profile;
     }
 }


### PR DESCRIPTION
Update WellKnownResponse, to handle an edge
case with Azure AD B2C tenants.

The users that are available for LoginService
are populated dynamically by the scenarios in VTP.
One can also login with a custom fnr.