### PR TITLE
Implement support for refresh_token

### DIFF
--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/auth/Oauth2AccessTokenResponse.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/auth/Oauth2AccessTokenResponse.java
@@ -20,10 +20,10 @@ public class Oauth2AccessTokenResponse {
     @JsonProperty("token_type")
     private String tokenType = "Bearer";
 
-    public Oauth2AccessTokenResponse(String idToken) {
+    public Oauth2AccessTokenResponse(String idToken, String refreshToken, String accessToken) {
         this.idToken = idToken;
-        this.refreshToken = UUID.randomUUID().toString();
-        this.accessToken = UUID.randomUUID().toString();
+        this.refreshToken = refreshToken;
+        this.accessToken = accessToken;
     }
 
     public void setAccessToken(String accessToken) {

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/auth/Oauth2RestService.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/auth/Oauth2RestService.java
@@ -174,13 +174,36 @@ public class Oauth2RestService {
             @FormParam("grant_type") String grantType,
             @FormParam("realm") String realm,
             @FormParam("code") String code,
+            @FormParam("refresh_token") String refreshToken,
             @FormParam("redirect_uri") String redirectUri) {
-        // dummy sikkerhet, returnerer alltid en idToken/refresh_token
-        String token = createIdToken(req, code);
-        LOG.info("Fikk parametere:" + req.getParameterMap().toString());
-        LOG.info("kall på /oauth2/access_token, opprettet token: " + token + " med redirect-url: " + redirectUri);
-        Oauth2AccessTokenResponse oauthResponse = new Oauth2AccessTokenResponse(token);
-        return Response.ok(oauthResponse).build();
+        if ("authorization_code".equals(grantType)) {
+            String token = createIdToken(req, code);
+            LOG.info("Fikk parametere:" + req.getParameterMap().toString());
+            LOG.info("kall på /oauth2/access_token, opprettet token: " + token + " med redirect-url: " + redirectUri);
+            String generatedRefreshToken = "refresh:" + code;
+            String generatedAccessToken = "access:" + code;
+            Oauth2AccessTokenResponse oauthResponse = new Oauth2AccessTokenResponse(token, generatedRefreshToken, generatedAccessToken);
+            return Response.ok(oauthResponse).build();
+        } else if ("refresh_token".equals(grantType)) {
+            if (!refreshToken.startsWith("refresh:")) {
+                String message = "Invalid refresh token " + code;
+                LOG.error(message);
+                return Response.status(Response.Status.FORBIDDEN).entity(message).build();
+            } else {
+                String username = refreshToken.substring(8);
+                String token = createIdToken(req, username);
+                LOG.info("Fikk parametere:" + req.getParameterMap().toString());
+                LOG.info("refresh-token-kall på /oauth2/access_token, opprettet nytt token: " + token);
+                String generatedRefreshToken = "refresh:" + username;
+                String generatedAccessToken = "access:" + username;
+                Oauth2AccessTokenResponse oauthResponse = new Oauth2AccessTokenResponse(token, generatedRefreshToken, generatedAccessToken);
+                return Response.ok(oauthResponse).build();
+            }
+        } else {
+            LOG.error("Unknown grant_type " + grantType);
+            return Response.serverError().entity("Unknown grant_type " + grantType).build();
+        }
+
     }
 
     private String getIssuer() {

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/azuread/navansatt/AzureAdNAVAnsattService.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/azuread/navansatt/AzureAdNAVAnsattService.java
@@ -45,7 +45,8 @@ public class AzureAdNAVAnsattService {
     @ApiOperation(value = "Azure AD Discovery url", notes = ("Mock impl av Azure AD discovery urlen. "))
     public Response wellKnown(@SuppressWarnings("unused") @Context HttpServletRequest req, @PathParam("tenant") String tenant, @QueryParam("p") String profile) {
         String baseUrl = getBaseUrl(req);
-        WellKnownResponse wellKnownResponse = new WellKnownResponse(baseUrl, tenant, profile);
+        String graphUrl = getGraphUrl(req);
+        WellKnownResponse wellKnownResponse = new WellKnownResponse(baseUrl, graphUrl, tenant, profile);
         return Response.ok(wellKnownResponse).build();
     }
 
@@ -72,21 +73,36 @@ public class AzureAdNAVAnsattService {
             @FormParam("client_id") String clientId,
             @FormParam("realm") String realm,
             @FormParam("code") String code,
+            @FormParam("refresh_token") String refreshToken,
             @FormParam("redirect_uri") String redirectUri) {
-        // dummy sikkerhet, returnerer alltid en idToken/refresh_token
-        String token = createIdToken(req, code, tenant, clientId);
-        LOG.info("Fikk parametere:" + req.getParameterMap().toString());
-        LOG.info("kall på /oauth2/access_token, opprettet token: " + token + " med redirect-url: " + redirectUri);
-        Oauth2AccessTokenResponse oauthResponse = new Oauth2AccessTokenResponse(token);
-        oauthResponse.setAccessToken(code.split(";")[0]);
-        return Response.ok(oauthResponse).build();
+        if ("authorization_code".equals(grantType)) {
+            String token = createIdToken(req, code, tenant, clientId);
+            String generatedRefreshToken = "refresh:" + code;
+            String generatedAccessToken = "access:" + code;
+            LOG.info("Fikk parametere:" + req.getParameterMap().toString());
+            LOG.info("kall på /oauth2/access_token, opprettet token: " + token + " med redirect-url: " + redirectUri);
+            Oauth2AccessTokenResponse oauthResponse = new Oauth2AccessTokenResponse(token, generatedRefreshToken, generatedAccessToken);
+            return Response.ok(oauthResponse).build();
+        } else if ("refresh_token".equals(grantType)) {
+            String usernameWithNonce = refreshToken.substring(8);
+            String token = createIdToken(req, usernameWithNonce /*+ ";"*/, tenant, clientId);
+            LOG.info("Fikk parametere:" + req.getParameterMap().toString());
+            LOG.info("refresh-token-kall på /oauth2/access_token, opprettet nytt token: " + token);
+            String generatedRefreshToken = "refresh:" + usernameWithNonce;
+            String generatedAccessToken = "access:" + usernameWithNonce;
+            Oauth2AccessTokenResponse oauthResponse = new Oauth2AccessTokenResponse(token, generatedRefreshToken, generatedAccessToken);
+            return Response.ok(oauthResponse).build();
+        } else {
+            LOG.error("Unknown grant_type " + grantType);
+            return Response.serverError().entity("Unknown grant_type " + grantType).build();
+        }
     }
 
     private String createIdToken(HttpServletRequest req, String code, String tenant, String clientId) {
         try {
             String[] codeData = code.split(";");
             String username = codeData[0];
-            String nonce = codeData[1];
+            String nonce = codeData.length > 1 ? codeData[1] : null;
             NAVAnsatt user = BasisdataProviderFileImpl.getInstance().getAnsatteIndeks().hentNAVAnsatt(username).orElseThrow(() -> new RuntimeException("Fant ikke NAV-ansatt med brukernavn " + username));
 
             String issuer = getIssuer(tenant);
@@ -211,6 +227,10 @@ public class AzureAdNAVAnsattService {
 
     private String getBaseUrl(@Context HttpServletRequest req) {
         return req.getScheme() + "://" + req.getServerName() + ":" + req.getServerPort() + "/rest/AzureAd";
+    }
+
+    private String getGraphUrl(@Context HttpServletRequest req) {
+        return req.getScheme() + "://" + req.getServerName() + ":" + req.getServerPort() + "/rest/MicrosoftGraphApi";
     }
 
     private String getIssuer(String tenant) {

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/azuread/navansatt/MicrosoftGraphApiMock.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/azuread/navansatt/MicrosoftGraphApiMock.java
@@ -1,6 +1,10 @@
 package no.nav.foreldrepenger.vtp.server.rest.azuread.navansatt;
 
 import io.swagger.annotations.Api;
+import no.nav.foreldrepenger.vtp.server.rest.auth.UserRepository;
+import no.nav.foreldrepenger.vtp.testmodell.ansatt.AnsatteIndeks;
+import no.nav.foreldrepenger.vtp.testmodell.ansatt.NAVAnsatt;
+import no.nav.foreldrepenger.vtp.testmodell.repo.impl.BasisdataProviderFileImpl;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -8,6 +12,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -16,9 +21,45 @@ import java.util.Map;
 public class MicrosoftGraphApiMock {
     @GET
     @Produces({ "application/json;charset=UTF-8" })
+    @Path("/oidc/userinfo")
+    public Response userinfo(@HeaderParam("Authorization") String auth) throws IOException {
+        if (!auth.startsWith("Bearer access:")) {
+            return Response
+                    .status(Response.Status.FORBIDDEN)
+                    .entity("Bad mock access token; must be on format Bearer access:<userid>")
+                    .build();
+        }
+
+        String accessToken = auth.substring(14);
+        String ident = accessToken.split(";")[0];
+
+        AnsatteIndeks ansatteIndeks = BasisdataProviderFileImpl.getInstance().getAnsatteIndeks();
+        NAVAnsatt ansatt = ansatteIndeks.hentNAVAnsatt(ident).orElseThrow(() -> new RuntimeException("Ansatt med ident " + ident + " ikke funnet i VTP."));
+
+        Map<String, String> response = new HashMap<>();
+        response.put("sub", ident);
+        response.put("name", ansatt.displayName);
+        response.put("family_name", ansatt.cn);
+        response.put("given_name", ansatt.givenname);
+        response.put("picture", "http://example.com/picture.jpg");
+        response.put("email", ansatt.email);
+        return Response.ok(response).build();
+    }
+
+    @GET
+    @Produces({ "application/json;charset=UTF-8" })
     @Path("/v1.0/me")
     public Response me(@HeaderParam("Authorization") String auth, @QueryParam("select") String select) {
-        String ident = auth.substring(7); // "Bearer userid" (The access token is mocked, being the same as the user ident)
+        if (!auth.startsWith("Bearer access:")) {
+            return Response
+                    .status(Response.Status.FORBIDDEN)
+                    .entity("Bad mock access token; must be on format Bearer access:<userid>")
+                    .build();
+        }
+
+        String accessToken = auth.substring(14);
+        String ident = accessToken.split(";")[0];
+
         Map<String, String> response = new HashMap<>();
         response.put("@odata.context", "https://graph.microsoft.com/v1.0/$metadata#users(" + select + ")/$entity");
         response.put("onPremisesSamAccountName", ident);

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/azuread/navansatt/WellKnownResponse.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/rest/azuread/navansatt/WellKnownResponse.java
@@ -30,6 +30,7 @@ userinfo_endpoint: "https://graph.microsoft.com/oidc/userinfo"
 * */
 class WellKnownResponse {
     private final String baseUrl;
+    private final String graphUrl;
     private final String tenant;
     private final String profile;
 
@@ -133,11 +134,12 @@ class WellKnownResponse {
 
     @JsonProperty("userinfo_endpoint")
     public String getUserinfoEndpoint() {
-        return baseUrl + "/rest/AzureGraphAPI/oidc/userinfo";
+        return graphUrl + "/oidc/userinfo";
     }
 
-    WellKnownResponse(String url, String tenant, String profile) {
-        this.baseUrl = url;
+    WellKnownResponse(String baseUrl, String graphUrl, String tenant, String profile) {
+        this.baseUrl = baseUrl;
+        this.graphUrl = graphUrl;
         this.tenant = tenant;
         this.profile = profile;
     }


### PR DESCRIPTION
This will let us simulate session refreshes, for logins
over more than 60 minutes.

Implemented both for OpenAM and Azure AD.