### PR TITLE
Use colorized status badged in request response list

### DIFF
--- a/frontend-react/src/components/Snitch/RequestResponseList.tsx
+++ b/frontend-react/src/components/Snitch/RequestResponseList.tsx
@@ -1,13 +1,15 @@
-import { Table } from "react-bootstrap";
+import { Badge, Table } from "react-bootstrap";
 import React from "react";
 import { RequestResponse } from "./types";
 import FormattedDate from "./FormattedDate";
+import { badgeVariant } from "./Snitch";
 
 interface RequestResponseListProps {
   requests: RequestResponse[];
   selectedRequest: RequestResponse | null;
   setSelectedRequest: (request: RequestResponse) => any;
 }
+
 export default function RequestResponseList(props: RequestResponseListProps) {
   return (
     <Table striped hover size="sm">
@@ -23,14 +25,8 @@ export default function RequestResponseList(props: RequestResponseListProps) {
       </thead>
       <tbody>
         {props.requests.map((request, i) => {
-          let rowClass = "";
-          if (request === props.selectedRequest) {
-            rowClass = "table-primary";
-          } else if (request.status >= 400 && request.status <= 499) {
-            rowClass = "table-warning";
-          } else if (request.status == 500) {
-            rowClass = "table-danger";
-          }
+          let rowClass =
+            request === props.selectedRequest ? "table-primary" : "";
 
           return (
             <tr
@@ -44,7 +40,11 @@ export default function RequestResponseList(props: RequestResponseListProps) {
               </td>
               <td>{request.method}</td>
               <td>{request.path}</td>
-              <td>{request.status}</td>
+              <td>
+                <Badge variant={badgeVariant(request.status)}>
+                  {request.status}
+                </Badge>
+              </td>
               <td>{request.handlerClass}</td>
               <td>{request.handlerMethod}</td>
             </tr>

--- a/frontend-react/src/components/Snitch/RequestResponseSummary.tsx
+++ b/frontend-react/src/components/Snitch/RequestResponseSummary.tsx
@@ -1,20 +1,8 @@
 import React from "react";
 import { Badge, Card } from "react-bootstrap";
-import { Variant } from "react-bootstrap/types";
 import { RequestResponse } from "./types";
 import FormattedDate from "./FormattedDate";
-
-function badgeVariant(status: number): Variant {
-  if (status >= 200 && status <= 299) {
-    return "success";
-  } else if (status >= 400 && status <= 499) {
-    return "warning";
-  } else if (status >= 500 && status <= 599) {
-    return "danger";
-  } else {
-    return "primary";
-  }
-}
+import { badgeVariant } from "./Snitch";
 
 interface SummaryProps {
   request: RequestResponse;

--- a/frontend-react/src/components/Snitch/Snitch.tsx
+++ b/frontend-react/src/components/Snitch/Snitch.tsx
@@ -5,6 +5,19 @@ import RequestResponseList from "./RequestResponseList";
 import PayloadSummary from "./PayloadSummary";
 import RequestResponseSummary from "./RequestResponseSummary";
 import useSnitchDataStream from "./useSnitchDataStream";
+import { Variant } from "react-bootstrap/types";
+
+export function badgeVariant(status: number): Variant {
+  if (status >= 200 && status <= 299) {
+    return "success";
+  } else if (status >= 400 && status <= 499) {
+    return "warning";
+  } else if (status >= 500 && status <= 599) {
+    return "danger";
+  } else {
+    return "primary";
+  }
+}
 
 export default () => {
   const [


### PR DESCRIPTION
Instead of colorizing the whole lines.

**Before**
![Skjermbilde 2020-12-29 kl  12 18 04](https://user-images.githubusercontent.com/5680727/103280565-05d88300-49d1-11eb-8052-5a68793b7a21.png)

**After**
![Skjermbilde 2020-12-29 kl  12 23 53](https://user-images.githubusercontent.com/5680727/103280570-07a24680-49d1-11eb-9e51-5c2eaf296395.png)
