### PR TITLE
Implement mock of the "old-fashioned" STS

### DIFF
--- a/mocks/auth-mock/src/main/kotlin/no/nav/pensjon/vtp/auth/OldFashionedMock.kt
+++ b/mocks/auth-mock/src/main/kotlin/no/nav/pensjon/vtp/auth/OldFashionedMock.kt
@@ -1,5 +1,6 @@
 package no.nav.pensjon.vtp.auth
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.nimbusds.jwt.JWTParser
 import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
@@ -27,7 +28,8 @@ class OldFashionedMock(
     private val logger = getLogger(OldFashionedMock::class.java)
 
     data class OldFashionedTokenResponse(
-        val access_token: String
+        @JsonProperty("access_token")
+        val accessToken: String
     )
     @PostMapping(value = ["/token"], consumes = [APPLICATION_FORM_URLENCODED_VALUE], produces = [APPLICATION_JSON_VALUE])
     @ApiOperation(value = "/token", notes = "Veksle inn Azure AD-token til OpenAM-token")
@@ -45,6 +47,6 @@ class OldFashionedMock(
             nonce = null,
             issuer = issuer
         ).create()
-        return ok(OldFashionedTokenResponse(access_token = token))
+        return ok(OldFashionedTokenResponse(accessToken = token))
     }
 }

--- a/mocks/auth-mock/src/main/kotlin/no/nav/pensjon/vtp/auth/OldFashionedMock.kt
+++ b/mocks/auth-mock/src/main/kotlin/no/nav/pensjon/vtp/auth/OldFashionedMock.kt
@@ -1,0 +1,50 @@
+package no.nav.pensjon.vtp.auth
+
+import com.nimbusds.jwt.JWTParser
+import io.swagger.annotations.Api
+import io.swagger.annotations.ApiOperation
+import no.nav.pensjon.vtp.testmodell.ansatt.AnsatteIndeks
+import org.slf4j.LoggerFactory.getLogger
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.http.ResponseEntity
+import org.springframework.http.ResponseEntity.badRequest
+import org.springframework.http.ResponseEntity.ok
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@Api(tags = ["OldFashioned"])
+@RequestMapping("/rest/old-fashioned")
+class OldFashionedMock(
+    private val ansatteIndeks: AnsatteIndeks,
+    private val jsonWebKeySupport: JsonWebKeySupport,
+    @Value("\${ISSO_OAUTH2_ISSUER}") val issuer: String
+) {
+    private val logger = getLogger(OldFashionedMock::class.java)
+
+    data class OldFashionedTokenResponse(
+        val access_token: String
+    )
+    @PostMapping(value = ["/token"], consumes = [APPLICATION_FORM_URLENCODED_VALUE], produces = [APPLICATION_JSON_VALUE])
+    @ApiOperation(value = "/token", notes = "Veksle inn Azure AD-token til OpenAM-token")
+    fun exchange(
+        @RequestParam("subject_token") subjectToken: String
+    ): ResponseEntity<Any> {
+        val email = JWTParser.parse(subjectToken).jwtClaimsSet.getStringClaim("preferred_username")
+        val ansatt = ansatteIndeks.findByEmail(email)
+        if (ansatt == null) {
+            return badRequest().body("Ansatt with e-mail $email was not found in VTP.")
+        }
+        val token = OidcTokenGenerator(
+            jsonWebKeySupport = jsonWebKeySupport,
+            subject = ansatt.cn,
+            nonce = null,
+            issuer = issuer
+        ).create()
+        return ok(OldFashionedTokenResponse(access_token = token))
+    }
+}

--- a/mocks/auth-mock/src/main/kotlin/no/nav/pensjon/vtp/auth/azuread/AzureAdNAVAnsattService.kt
+++ b/mocks/auth-mock/src/main/kotlin/no/nav/pensjon/vtp/auth/azuread/AzureAdNAVAnsattService.kt
@@ -41,6 +41,15 @@ class AzureAdNAVAnsattService(private val ansatteIndeks: AnsatteIndeks, private 
     @ApiOperation(value = "azureAd/discovery/keys", notes = "Mock impl av Azure AD jwk_uri")
     fun authorize() = jsonWebKeySupport.jwks()
 
+    @PostMapping(value = ["/{tenant}/mock-token"], produces = [APPLICATION_JSON_VALUE])
+    @ApiOperation(value = "azureAd/mock-token", notes = "Generer Azure AD-token for testing")
+    fun mockToken(
+        @PathVariable("tenant") tenant: String,
+        @RequestParam("client_id") clientId: String,
+    ): ResponseEntity<*> {
+        return ok(createIdToken("lukesky;foobar", tenant, clientId))
+    }
+
     @PostMapping(value = ["/{tenant}/oauth2/v2.0/token"], produces = [APPLICATION_JSON_VALUE])
     @ApiOperation(value = "azureAd/access_token", notes = "Mock impl av Azure AD access_token")
     fun accessToken(
@@ -83,7 +92,7 @@ class AzureAdNAVAnsattService(private val ansatteIndeks: AnsatteIndeks, private 
 
         return azureOidcToken(
             jsonWebKeySupport = jsonWebKeySupport,
-            subject = codeData[0],
+            email = user.email,
             nonce = if (codeData.size > 1) codeData[1] else null,
             issuer = getIssuer(tenant),
             groups = user.groups.map { ldapGroupName: String -> toAzureGroupId(ldapGroupName) },

--- a/mocks/auth-mock/src/main/kotlin/no/nav/pensjon/vtp/auth/azuread/AzureOidcTokenGenerator.kt
+++ b/mocks/auth-mock/src/main/kotlin/no/nav/pensjon/vtp/auth/azuread/AzureOidcTokenGenerator.kt
@@ -1,6 +1,7 @@
 package no.nav.pensjon.vtp.auth.azuread
 
 import no.nav.pensjon.vtp.auth.JsonWebKeySupport
+import org.apache.commons.codec.digest.DigestUtils
 import org.jose4j.jwt.JwtClaims
 import org.jose4j.jwt.NumericDate
 import org.springframework.util.ObjectUtils
@@ -9,7 +10,7 @@ import kotlin.collections.ArrayList
 
 fun azureOidcToken(
     jsonWebKeySupport: JsonWebKeySupport,
-    subject: String,
+    email: String,
     nonce: String?,
     aud: List<String> = ArrayList(),
     groups: List<String> = ArrayList(),
@@ -25,7 +26,12 @@ fun azureOidcToken(
     claims.setGeneratedJwtId()
     claims.issuedAt = issuedAt
     claims.notBefore = issuedAt
-    claims.subject = subject
+
+    // subject is just an Azure-specific ID. For mocking purposes, we just use a shasum, to have a
+    // consistent mapping between e-mail address (preferred_username) and Azure ID.
+    claims.subject = DigestUtils.sha256Hex(email)
+    claims.setClaim("preferred_username", email)
+
     claims.setClaim("ver", "2.0")
     if (!ObjectUtils.isEmpty(nonce)) {
         claims.setClaim("nonce", nonce)

--- a/model/src/main/kotlin/no/nav/pensjon/vtp/testmodell/ansatt/AnsatteIndeks.kt
+++ b/model/src/main/kotlin/no/nav/pensjon/vtp/testmodell/ansatt/AnsatteIndeks.kt
@@ -17,6 +17,10 @@ class AnsatteIndeks {
         return ansatte.firstOrNull { it.cn == ident }
     }
 
+    fun findByEmail(email: String): NAVAnsatt? {
+        return ansatte.firstOrNull { it.email == email }
+    }
+
     fun findBySnIgnoreCase(sn: String): NAVAnsatt? {
         return ansatte.firstOrNull { sn.equals(it.sn, ignoreCase = true) }
     }


### PR DESCRIPTION
- Also made adjustments to the mock Azure AD token, to make it more
  consistent with a real-world token.
- Add frontend tooling to generate other OIDC token types than STS