### PR TITLE
PL-1577: Added missing Oppgave API endpoints

### DIFF
--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/oppgave/rest/FerdigstillOppgaverResponse.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/oppgave/rest/FerdigstillOppgaverResponse.kt
@@ -1,0 +1,12 @@
+package no.nav.pensjon.vtp.mocks.oppgave.rest
+
+import io.swagger.annotations.ApiModelProperty
+
+data class FerdigstillOppgaverResponse(
+    val feilet: Int = 0,
+    val suksess: Int = 0,
+    val totalt: Int = 0,
+
+    @ApiModelProperty(value = "HTTP-kode -> oppgaveID")
+    val data: Map<Int, List<Long>> = HashMap()
+)

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/oppgave/rest/Oppfolging.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/oppgave/rest/Oppfolging.kt
@@ -1,0 +1,12 @@
+package no.nav.pensjon.vtp.mocks.oppgave.rest
+
+class Oppfolging {
+
+    var id: Long? = null
+    var oppgaveId: Long? = null
+    var kommentar: String? = null
+    var opprettetAv: String? = null
+    var endretAv: String? = null
+    var opprettetTidspunkt: String? = null
+    var endretTidspunkt: String? = null
+}

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/oppgave/rest/OppgaveMockImpl.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/oppgave/rest/OppgaveMockImpl.kt
@@ -6,22 +6,22 @@ import io.swagger.annotations.ApiImplicitParams
 import io.swagger.annotations.ApiOperation
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @Api(tags = ["Oppgave Mock"])
 @RequestMapping(
-    value = ["/rest/oppgave/api/v1/oppgaver"],
-    produces = [MediaType.APPLICATION_JSON_VALUE],
-    consumes = [MediaType.APPLICATION_JSON_VALUE]
+    value = ["/rest/oppgave/api/v1/oppgaver"]
 )
 class OppgaveMockImpl {
     private val oppgaver = mutableListOf<Oppgave>()
     private var oppgaveId = 1L
 
-    @PutMapping
+    private val oppfolginger = mutableListOf<Oppfolging>()
+    private var oppfolgingId = 1L
+
+    @PostMapping
     @ApiOperation(value = "Opprett oppgave")
     @ApiImplicitParams(
         ApiImplicitParam(
@@ -39,6 +39,27 @@ class OppgaveMockImpl {
         oppgave.id = oppgaveId++
         oppgaver.add(oppgave)
         return ResponseEntity.status(HttpStatus.CREATED).body(oppgave)
+    }
+
+    @PutMapping("/{oppgaveid}")
+    @ApiOperation(value = "Oppdater oppgave")
+    @ApiImplicitParams(
+        ApiImplicitParam(
+            name = "X-Correlation-ID",
+            required = true,
+            dataType = "string",
+            paramType = "header"
+        ),
+        ApiImplicitParam(name = "Authorization", required = true, dataType = "string", paramType = "header")
+    )
+    fun oppdaterOppgave(
+        @PathVariable("oppgaveid") oppgaveId: Long,
+        @RequestBody oppgave: Oppgave,
+        @RequestHeader httpHeaders: HttpHeaders?
+    ): ResponseEntity<*> {
+        oppgaver.removeIf { it.id == oppgaveId }
+        oppgaver.add(oppgave)
+        return ResponseEntity.status(HttpStatus.OK).build<Any>()
     }
 
     @GetMapping
@@ -60,8 +81,97 @@ class OppgaveMockImpl {
         HentOppgaverResponse(antallTreffTotalt = oppgaver.size, oppgaver = oppgaver)
 
     @GetMapping("/{oppgaveid}")
-    @ApiOperation(value = "Hent oppgave")
+    @ApiOperation(value = "Hent oppgave", response = Oppgave::class)
+    @ApiImplicitParams(
+        ApiImplicitParam(
+            name = "X-Correlation-ID",
+            required = true,
+            dataType = "string",
+            paramType = "header"
+        ),
+        ApiImplicitParam(name = "Authorization", required = true, dataType = "string", paramType = "header")
+    )
     fun hentOppgave(
+        @RequestHeader httpHeaders: HttpHeaders?,
         @PathVariable("oppgaveid") oppgaveId: Long
-    ) = oppgaver.first { oppgave -> oppgave.id == oppgaveId }
+    ) =
+        oppgaver.firstOrNull { it.id == oppgaveId }
+
+    @PatchMapping
+    @ApiOperation(value = "Ferdigstille oppgaver", response = FerdigstillOppgaverResponse::class)
+    @ApiImplicitParams(
+        ApiImplicitParam(
+            name = "X-Correlation-ID",
+            required = true,
+            dataType = "string",
+            paramType = "header"
+        ),
+        ApiImplicitParam(name = "Authorization", required = true, dataType = "string", paramType = "header")
+    )
+    fun bulkUpdateOppgaver(): FerdigstillOppgaverResponse {
+        val antallOppdaterte = oppgaver.size
+        // Pesys benytter dette bare til å ferdigstille oppgaver
+        oppgaver.clear()
+        oppfolginger.clear()
+        return FerdigstillOppgaverResponse(suksess = antallOppdaterte, totalt = antallOppdaterte)
+    }
+
+    @GetMapping("/{oppgaveid}/oppfolging")
+    @ApiOperation(value = "Hent oppfølginger for oppgave")
+    @ApiImplicitParams(
+        ApiImplicitParam(
+            name = "X-Correlation-ID",
+            required = true,
+            dataType = "string",
+            paramType = "header"
+        ),
+        ApiImplicitParam(name = "Authorization", required = true, dataType = "string", paramType = "header")
+    )
+    fun hentOppfolginger(
+        @PathVariable("oppgaveid") oppgaveId: Long
+    ): ResponseEntity<*> {
+        val oppfolginger = oppfolginger.filter { it.oppgaveId == oppgaveId }
+        return ResponseEntity.status(HttpStatus.OK).body(oppfolginger)
+    }
+
+    @PostMapping("/{oppgaveid}/oppfolging")
+    @ApiOperation(value = "Opprett oppfølging")
+    @ApiImplicitParams(
+        ApiImplicitParam(
+            name = "X-Correlation-ID",
+            required = true,
+            dataType = "string",
+            paramType = "header"
+        ),
+        ApiImplicitParam(name = "Authorization", required = true, dataType = "string", paramType = "header")
+    )
+    fun opprettOppfolging(
+        @PathVariable("oppgaveid") oppgaveId: Long,
+        @RequestBody oppfolging: Oppfolging,
+        @RequestHeader httpHeaders: HttpHeaders?
+    ): ResponseEntity<*> {
+        oppfolging.id = oppfolgingId++
+        oppfolginger.add(oppfolging.apply { this.oppgaveId = oppgaveId })
+        return ResponseEntity.status(HttpStatus.CREATED).body(oppfolging)
+    }
+
+    @PutMapping("/{oppgaveid}/oppfolging/{oppfolgingid}")
+    @ApiOperation(value = "Oppdater oppfølging")
+    @ApiImplicitParams(
+        ApiImplicitParam(
+            name = "X-Correlation-ID",
+            required = true,
+            dataType = "string",
+            paramType = "header"
+        ),
+        ApiImplicitParam(name = "Authorization", required = true, dataType = "string", paramType = "header")
+    )
+    fun oppdaterOppfolging(
+        @PathVariable("oppgaveid") oppgaveId: Long,
+        @RequestBody oppfolging: Oppfolging,
+        @RequestHeader httpHeaders: HttpHeaders?
+    ) {
+        oppfolginger.removeIf { e -> e.id == oppfolging.id }
+        oppfolginger.add(oppfolging.apply { this.oppgaveId = oppgaveId })
+    }
 }

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/psak/aktoerregister/rest/api/v1/PsakAktoerIdentMock.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/psak/aktoerregister/rest/api/v1/PsakAktoerIdentMock.kt
@@ -21,9 +21,9 @@ private const val GJELDENDE = "gjeldende"
 @Api(tags = ["aktoerregister"])
 @RequestMapping("/rest/psak/aktoerregister/api/v1/identer")
 class PsakAktoerIdentMock {
-    // TODO (TEAM FAMILIE) Lag mock-responser fra scenario NOSONAR
-    private val personIdentMock = "12345678910"
+    private val personIdentMock = "01015746161"
     private val aktoerIdMock = "1234567891011"
+
     @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
     fun getIdenter(
         @RequestHeader(NAV_IDENTER_HEADER_KEY) requestIdenter: Set<String>,
@@ -34,14 +34,14 @@ class PsakAktoerIdentMock {
 
         val identinfo: Identinfo = if (AKTOERID_IDENTGRUPPE == identgruppe) {
             Identinfo(
-                ident = personIdentMock,
-                identgruppe = PERSONIDENT_IDENTGRUPPE,
+                ident = aktoerIdMock,
+                identgruppe = AKTOERID_IDENTGRUPPE,
                 gjeldende = true
             )
         } else {
             Identinfo(
-                ident = aktoerIdMock,
-                identgruppe = AKTOERID_IDENTGRUPPE,
+                ident = personIdentMock,
+                identgruppe = PERSONIDENT_IDENTGRUPPE,
                 gjeldende = true
             )
         }

--- a/vtp-pensjon-application/src/test/kotlin/no/nav/pensjon/vtp/mocks/oppgave/rest/OppgaveIntegrationTest.kt
+++ b/vtp-pensjon-application/src/test/kotlin/no/nav/pensjon/vtp/mocks/oppgave/rest/OppgaveIntegrationTest.kt
@@ -36,14 +36,14 @@ class OppgaveIntegrationTest @Autowired constructor() {
         """
 
         this.mockMvc!!.perform(
-            MockMvcRequestBuilders.put("/rest/oppgave/api/v1/oppgaver")
+            MockMvcRequestBuilders.post("/rest/oppgave/api/v1/oppgaver")
                 .content(opprettOppgaveRequest)
                 .contentType(MediaType.APPLICATION_JSON)
         )
             .andExpect(MockMvcResultMatchers.status().is2xxSuccessful)
 
         this.mockMvc.perform(
-            MockMvcRequestBuilders.put("/rest/oppgave/api/v1/oppgaver")
+            MockMvcRequestBuilders.post("/rest/oppgave/api/v1/oppgaver")
                 .content(opprettOppgaveRequest)
                 .contentType(MediaType.APPLICATION_JSON)
         )


### PR DESCRIPTION
Vedrørende korrigering av **Aktør**-tjenesten: https://confluence.adeo.no/pages/viewpage.action?pageId=277329112 

Fødselsnummeret som benyttes i norskIdent ble generert av VTP/pensjon-testdata.

Vi burde vel forøvrig slette den andre implementasjonen. Er jo ikke delt repo lengre.