### PR TITLE
NOM Mock 

### DIFF
--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/nom/NomMock.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/nom/NomMock.kt
@@ -14,5 +14,5 @@ class NomMock(private val personModellRepository: PersonModellRepository) {
 
     @GetMapping(path = ["/skjermet"])
     fun skjermet(@RequestParam("personident", required = true) personident: String) =
-            personModellRepository.findById(personident)?.egenansatt ?: false
+        personModellRepository.findById(personident)?.egenansatt ?: false
 }

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/nom/NomMock.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/nom/NomMock.kt
@@ -1,0 +1,18 @@
+package no.nav.pensjon.vtp.mocks.nom
+
+import io.swagger.annotations.Api
+import no.nav.pensjon.vtp.testmodell.personopplysning.PersonModellRepository
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@Api(tags = ["NOM"])
+@RequestMapping("/rest")
+class NomMock(private val personModellRepository: PersonModellRepository) {
+
+    @GetMapping(path = ["/skjermet"])
+    fun skjermet(@RequestParam("personident", required = true) personident: String) =
+            personModellRepository.findById(personident)?.egenansatt ?: false
+}

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/psak/PDLMock.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/psak/PDLMock.kt
@@ -24,11 +24,6 @@ class PDLMock {
         return java.util.Map.of("errors", listOf<Map<String, String?>>(errors))
     }
 
-    @GetMapping(path = ["/skjermet"])
-    fun skjermet(@RequestParam("ident") ident: String?): Boolean {
-        return false
-    }
-
     @GetMapping(path = ["/api/v1/personer/kontaktinformasjon"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun getIdenter(@RequestHeader("Nav-Personidenter") requestIdenter: String?): DkifResponse {
         val kontakt = requestIdenter

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/load/PersonTemplate.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/load/PersonTemplate.kt
@@ -15,6 +15,7 @@ data class PersonTemplate(
     val fødselsdato: LocalDate?,
     val dødsdato: LocalDate?,
     val diskresjonskode: Diskresjonskoder?,
+    val egenansatt: Boolean,
     val språk: String?,
     val kjønn: Kjønn,
     val gjeldendeAdresseType: AdresseType?,

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/personopplysning/PersonModell.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/personopplysning/PersonModell.kt
@@ -22,6 +22,7 @@ data class PersonModell(
     val fødselsdato: LocalDate?,
     val dødsdato: LocalDate?,
     val diskresjonskode: Diskresjonskoder?,
+    val egenansatt: Boolean,
     val språk: String?,
     val kjønn: Kjønn?,
     val gjeldendeAdresseType: AdresseType?,

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/repo/impl/Mapper.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/repo/impl/Mapper.kt
@@ -53,6 +53,7 @@ class Mapper(val identer: LokalIdentIndeks, val adresseIndeks: AdresseIndeks, va
             fødselsdato = i.fødselsdato,
             dødsdato = i.dødsdato,
             diskresjonskode = i.diskresjonskode,
+            egenansatt = i.egenansatt,
             språk = i.språk,
             kjønn = i.kjønn,
             gjeldendeAdresseType = i.gjeldendeAdresseType,


### PR DESCRIPTION
Drar ut mocking av NAVs Organisasjons Master (NOM) fra PDLMock til egen NomMock. Trenger ikke egen ping mock siden pesys pinger ved å gjøre et tomt kall mot /skjermet endepunketet.

Lagger datagrunnlaget i PersonModell->_egenansatt_ som da settes i _søker_ i personopplysninger.