### PR TITLE
Add support for generating ad hoc users for testing

### DIFF
--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/auth/AnsattRequest.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/auth/AnsattRequest.kt
@@ -1,0 +1,6 @@
+package no.nav.pensjon.vtp.auth
+
+data class AnsattRequest(
+    val groups: List<String>,
+    val units: List<String>,
+)

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/configuration/RepositoryConfiguration.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/configuration/RepositoryConfiguration.kt
@@ -5,6 +5,7 @@ import no.nav.pensjon.vtp.testmodell.brev.BrevMetadataIndeks
 import no.nav.pensjon.vtp.testmodell.enheter.EnheterIndeks
 import no.nav.pensjon.vtp.testmodell.pensjon_testdata.PensjonTestdataService
 import no.nav.pensjon.vtp.testmodell.pensjon_testdata.PensjonTestdataServiceImpl
+import no.nav.pensjon.vtp.testmodell.pensjon_testdata.PensjonTestdataServiceNull
 import no.nav.pensjon.vtp.testmodell.personopplysning.AdresseIndeks
 import no.nav.pensjon.vtp.testmodell.repo.TestscenarioTemplateRepository
 import no.nav.pensjon.vtp.testmodell.repo.impl.BasisdataProviderFileImpl
@@ -32,9 +33,11 @@ class RepositoryConfiguration {
     }
 
     @Bean
-    fun pensjonTestdataService(@Value("\${pensjon.testdata.url}") pensjonTestdataUrl: String): PensjonTestdataService {
-        return PensjonTestdataServiceImpl(pensjonTestdataUrl)
-    }
+    fun pensjonTestdataService(@Value("\${pensjon.testdata.url}") pensjonTestdataUrl: String?): PensjonTestdataService =
+        when {
+            pensjonTestdataUrl.isNullOrBlank() -> PensjonTestdataServiceNull()
+            else -> PensjonTestdataServiceImpl(pensjonTestdataUrl)
+        }
 
     @Bean
     fun enheterIndeks(): EnheterIndeks {

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/journalpost/dokarkiv/JournalpostMapper.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/journalpost/dokarkiv/JournalpostMapper.kt
@@ -10,7 +10,6 @@ import no.nav.pensjon.vtp.testmodell.dokument.modell.DokumentVariantInnhold
 import no.nav.pensjon.vtp.testmodell.dokument.modell.JournalpostBruker
 import no.nav.pensjon.vtp.testmodell.dokument.modell.JournalpostModell
 import no.nav.pensjon.vtp.testmodell.dokument.modell.koder.*
-import no.nav.pensjon.vtp.testmodell.dokument.modell.koder.Arkivfiltype
 import no.nav.pensjon.vtp.testmodell.dokument.modell.koder.DokumentTilknyttetJournalpost.HOVEDDOKUMENT
 import no.nav.pensjon.vtp.testmodell.dokument.modell.koder.DokumentTilknyttetJournalpost.VEDLEGG
 import no.nav.pensjon.vtp.testmodell.dokument.modell.koder.Journalposttyper.*

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/oppgave/gask/sak/v1/GsakRepo.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/oppgave/gask/sak/v1/GsakRepo.kt
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Component
 import java.time.LocalDate.now
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import java.util.*
 import java.util.concurrent.atomic.AtomicInteger
 
 @Component

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/unleash/UnleashController.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/unleash/UnleashController.kt
@@ -6,7 +6,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate.now
 import java.time.LocalDateTime
-import java.util.*
 import javax.servlet.http.Cookie
 import javax.servlet.http.HttpServletResponse
 

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/virksomhet/dokumentproduksjon/v2/DocContext.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/virksomhet/dokumentproduksjon/v2/DocContext.kt
@@ -6,7 +6,6 @@ import org.apache.pdfbox.pdmodel.PDPageContentStream
 import org.apache.pdfbox.pdmodel.font.PDFont
 import java.awt.Color
 import java.io.ByteArrayOutputStream
-import java.util.*
 import kotlin.math.roundToInt
 
 private fun newPage(doc: PDDocument, fontHeight: Int, fontSize: Int): PageContext {

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/virksomhet/inntekt/hentinntektlistebolk/modell/HentInntektlisteBolkMapperRest.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/virksomhet/inntekt/hentinntektlistebolk/modell/HentInntektlisteBolkMapperRest.kt
@@ -8,12 +8,9 @@ import no.nav.pensjon.vtp.testmodell.personopplysning.PersonModellRepository
 import no.nav.tjenester.aordningen.inntektsinformasjon.*
 import no.nav.tjenester.aordningen.inntektsinformasjon.inntekt.Inntekt
 import org.springframework.stereotype.Component
-import java.lang.IllegalStateException
-import java.lang.RuntimeException
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
-import java.util.*
 
 @Component
 class HentInntektlisteBolkMapperRest(private val personModellRepository: PersonModellRepository) {

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/virksomhet/inntekt/v3/InntektMockImpl.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/virksomhet/inntekt/v3/InntektMockImpl.kt
@@ -16,7 +16,6 @@ import no.nav.tjeneste.virksomhet.inntekt.v3.informasjon.inntekt.PersonIdent
 import no.nav.tjeneste.virksomhet.inntekt.v3.meldinger.*
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
-import java.util.*
 import javax.jws.*
 import javax.xml.ws.RequestWrapper
 import javax.xml.ws.ResponseWrapper

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/virksomhet/inntekt/v3/modell/HentInntektlistBolkMapper.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/virksomhet/inntekt/v3/modell/HentInntektlistBolkMapper.kt
@@ -9,7 +9,6 @@ import no.nav.pensjon.vtp.util.asXMLGregorianCalendar
 import no.nav.tjeneste.virksomhet.inntekt.v3.informasjon.inntekt.*
 import java.math.BigDecimal
 import java.time.LocalDate
-import java.util.*
 
 object HentInntektlistBolkMapper {
     fun makeArbeidsInntektIdent(modell: InntektskomponentModell, aktoer: Aktoer): ArbeidsInntektIdent {

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/virksomhet/person/v3/AdresseAdapter.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/virksomhet/person/v3/AdresseAdapter.kt
@@ -3,7 +3,6 @@ package no.nav.pensjon.vtp.mocks.virksomhet.person.v3
 import no.nav.pensjon.vtp.testmodell.personopplysning.*
 import no.nav.pensjon.vtp.util.asXMLGregorianCalendar
 import no.nav.tjeneste.virksomhet.person.v3.informasjon.*
-import java.lang.UnsupportedOperationException
 import java.time.LocalDate
 
 fun setAdresser(bruker: Bruker, person: PersonModell) {

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/ansatt/AnsattService.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/ansatt/AnsattService.kt
@@ -1,0 +1,40 @@
+package no.nav.pensjon.vtp.testmodell.ansatt
+
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class AnsattService(
+    private var ansatteIndeks: AnsatteIndeks,
+    private var eventPublisher: ApplicationEventPublisher
+) {
+    fun addAnnsatt(
+        cn: String = UUID.randomUUID().toString(),
+        givenname: String = UUID.randomUUID().toString(),
+        sn: String = UUID.randomUUID().toString(),
+        displayName: String = UUID.randomUUID().toString(),
+        email: String = UUID.randomUUID().toString(),
+        groups: List<String>,
+        enheter: List<Long>,
+        generated: Boolean
+    ) = ansatteIndeks.save(
+        NAVAnsatt(
+            cn = cn,
+            givenname = givenname,
+            sn = sn,
+            displayName = displayName,
+            email = email,
+            groups = groups,
+            enheter = enheter,
+            generated = generated,
+        )
+    ).also {
+        eventPublisher.publishEvent(NewAnsattEvent(it))
+    }
+
+    fun findAll(includeGenerated: Boolean) = ansatteIndeks.findAll()
+        .filter { includeGenerated || !it.generated }
+
+    fun findByCn(ident: String) = ansatteIndeks.findByCn(ident)
+}

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/ansatt/AnsatteIndeks.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/ansatt/AnsatteIndeks.kt
@@ -1,13 +1,13 @@
 package no.nav.pensjon.vtp.testmodell.ansatt
 
-import java.util.*
-
 class AnsatteIndeks {
     private val ansatte: MutableList<NAVAnsatt> = ArrayList()
 
     fun findAll(): List<NAVAnsatt> {
         return ansatte
     }
+
+    fun save(ansatt: NAVAnsatt) = ansatt.also(ansatte::add)
 
     fun saveAll(ansatte: List<NAVAnsatt>) {
         this.ansatte.addAll(ansatte)

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/ansatt/NAVAnsatt.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/ansatt/NAVAnsatt.kt
@@ -7,5 +7,6 @@ data class NAVAnsatt(
     val displayName: String,
     val email: String,
     val groups: List<String>,
-    val enheter: List<Long>
+    val enheter: List<Long>,
+    val generated: Boolean
 )

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/ansatt/NewAnsattEvent.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/ansatt/NewAnsattEvent.kt
@@ -1,0 +1,3 @@
+package no.nav.pensjon.vtp.testmodell.ansatt
+
+data class NewAnsattEvent(val ansatt: NAVAnsatt)

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/dokument/modell/JournalpostModell.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/dokument/modell/JournalpostModell.kt
@@ -4,7 +4,6 @@ import no.nav.pensjon.vtp.testmodell.dokument.modell.koder.Arkivtema
 import no.nav.pensjon.vtp.testmodell.dokument.modell.koder.Journalposttyper
 import no.nav.pensjon.vtp.testmodell.dokument.modell.koder.Journalstatus
 import java.time.LocalDateTime
-import java.util.*
 
 data class JournalpostModell(
     var journalpostId: String? = null,

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/enheter/EnheterIndeks.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/enheter/EnheterIndeks.kt
@@ -1,7 +1,5 @@
 package no.nav.pensjon.vtp.testmodell.enheter
 
-import java.util.*
-
 class EnheterIndeks(private val byDiskresjonskode: MutableMap<String, Norg2Modell> = HashMap()) {
     fun saveAll(enheter: Collection<Norg2Modell>) {
         enheter.forEach { m: Norg2Modell -> byDiskresjonskode.putIfAbsent(m.diskresjonskode, m) }

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/inntektytelse/arbeidsforhold/Arbeidsforhold.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/inntektytelse/arbeidsforhold/Arbeidsforhold.kt
@@ -2,7 +2,6 @@ package no.nav.pensjon.vtp.testmodell.inntektytelse.arbeidsforhold
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
-import java.util.*
 
 data class Arbeidsforhold(
     @JsonProperty("arbeidsavtaler")

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/inntektytelse/arbeidsforhold/ArbeidsforholdModell.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/inntektytelse/arbeidsforhold/ArbeidsforholdModell.kt
@@ -2,7 +2,6 @@ package no.nav.pensjon.vtp.testmodell.inntektytelse.arbeidsforhold
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
-import java.util.*
 
 data class ArbeidsforholdModell(
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/inntektytelse/arena/ArenaModell.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/inntektytelse/arena/ArenaModell.kt
@@ -3,7 +3,6 @@ package no.nav.pensjon.vtp.testmodell.inntektytelse.arena
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import no.nav.pensjon.vtp.testmodell.FeilKode
-import java.util.*
 
 data class ArenaModell(
     @JsonProperty("feilkode")

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/inntektytelse/arena/ArenaSak.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/inntektytelse/arena/ArenaSak.kt
@@ -3,7 +3,6 @@ package no.nav.pensjon.vtp.testmodell.inntektytelse.arena
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import no.nav.pensjon.vtp.testmodell.inntektytelse.RelatertYtelseTema
-import java.util.*
 
 data class ArenaSak(
     @JsonProperty("saksnummer")

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/inntektytelse/arena/ArenaVedtak.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/inntektytelse/arena/ArenaVedtak.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.math.BigDecimal
 import java.time.LocalDate
-import java.util.*
 
 data class ArenaVedtak(
     @JsonProperty("kravMottattDato")

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/inntektytelse/inntektkomponent/InntektskomponentModell.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/inntektytelse/inntektkomponent/InntektskomponentModell.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
-import java.util.ArrayList
 
 class InntektskomponentModell {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/inntektytelse/sigrun/SigrunModell.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/inntektytelse/sigrun/SigrunModell.kt
@@ -2,7 +2,6 @@ package no.nav.pensjon.vtp.testmodell.inntektytelse.sigrun
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
-import java.util.*
 
 data class SigrunModell(
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/inntektytelse/trex/TRexModell.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/inntektytelse/trex/TRexModell.kt
@@ -2,7 +2,6 @@ package no.nav.pensjon.vtp.testmodell.inntektytelse.trex
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
-import java.util.ArrayList
 
 data class TRexModell(
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/medlemskap/MedlemskapModell.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/medlemskap/MedlemskapModell.kt
@@ -1,7 +1,5 @@
 package no.nav.pensjon.vtp.testmodell.medlemskap
 
-import java.util.*
-
 data class MedlemskapModell(
     val perioder: List<MedlemskapperiodeModell> = ArrayList()
 )

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/organisasjon/OrganisasjonModeller.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/organisasjon/OrganisasjonModeller.kt
@@ -2,7 +2,6 @@ package no.nav.pensjon.vtp.testmodell.organisasjon
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
-import java.util.*
 
 data class OrganisasjonModeller(
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/pensjon_testdata/PensjonTestdataServiceImpl.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/pensjon_testdata/PensjonTestdataServiceImpl.kt
@@ -5,9 +5,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.web.client.RestTemplate
-import org.springframework.web.client.postForEntity
 import org.springframework.web.client.postForObject
-import java.lang.RuntimeException
 
 class PensjonTestdataServiceImpl(private val baseUrl: String) : PensjonTestdataService {
     private val logger = LoggerFactory.getLogger(javaClass)

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/pensjon_testdata/PensjonTestdataServiceNull.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/pensjon_testdata/PensjonTestdataServiceNull.kt
@@ -4,6 +4,6 @@ import no.nav.pensjon.vtp.testmodell.repo.Testscenario
 
 class PensjonTestdataServiceNull : PensjonTestdataService {
     override fun opprettData(testscenario: Testscenario) {}
-    override fun opprettTestdataScenario(dto: Testscenario, caseId: String): String { TODO("Not yet implemented") }
-    override fun hentScenarios(): List<PensjonTestdataScenario> { TODO("Not yet implemented") }
+    override fun opprettTestdataScenario(dto: Testscenario, caseId: String): String = ""
+    override fun hentScenarios(): List<PensjonTestdataScenario> = emptyList()
 }

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/personopplysning/AdresseIndeks.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/personopplysning/AdresseIndeks.kt
@@ -1,7 +1,5 @@
 package no.nav.pensjon.vtp.testmodell.personopplysning
 
-import java.util.*
-
 class AdresseIndeks {
     private val adresser: MutableList<AdresseModell> = ArrayList()
 

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/repo/impl/JournalRepositoryImpl.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/repo/impl/JournalRepositoryImpl.kt
@@ -6,7 +6,6 @@ import no.nav.pensjon.vtp.testmodell.repo.JournalRepository
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime.now
 import java.time.format.DateTimeFormatter.ofPattern
-import java.util.*
 import java.util.concurrent.atomic.AtomicInteger
 
 @Repository

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/repo/impl/TestscenarioFraTemplateMapper.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/repo/impl/TestscenarioFraTemplateMapper.kt
@@ -15,8 +15,6 @@ import no.nav.pensjon.vtp.testmodell.util.JsonMapper
 import no.nav.pensjon.vtp.testmodell.util.VariabelContainer
 import org.springframework.stereotype.Component
 import java.io.IOException
-import java.lang.IllegalArgumentException
-import java.lang.RuntimeException
 
 @Component
 class TestscenarioFraTemplateMapper {

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/repo/impl/TestscenarioTemplateLoader.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/repo/impl/TestscenarioTemplateLoader.kt
@@ -8,7 +8,6 @@ import org.springframework.core.io.Resource
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
-import java.util.*
 
 const val LOCATION_PATTERN = "classpath:/scenarios/**/vars.json"
 

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/scenario/TestscenarioRestTjeneste.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/scenario/TestscenarioRestTjeneste.kt
@@ -19,7 +19,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.http.ResponseEntity.*
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.client.HttpClientErrorException
-import java.util.*
 
 @RestController
 @Api(tags = ["Testscenario"])

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/scenario/dto/TemplateDto.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/scenario/dto/TemplateDto.kt
@@ -2,7 +2,6 @@ package no.nav.pensjon.vtp.testmodell.scenario.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
-import java.util.*
 
 /** Beskriver en template,inklusiv liste av variable og deres verdier.  */
 data class TemplateDto(

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/util/FindTemplateVariables.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/testmodell/util/FindTemplateVariables.kt
@@ -12,9 +12,6 @@ import com.fasterxml.jackson.databind.module.SimpleModule
 import no.nav.pensjon.vtp.testmodell.repo.TemplateVariable
 import java.io.IOException
 import java.io.Reader
-import java.lang.IllegalArgumentException
-import java.lang.StringBuilder
-import java.util.*
 import java.util.regex.Pattern
 
 /** Scanner input for template variable og finner type, path etc.  */


### PR DESCRIPTION
These users are created by posting the wanted groups and units. This can be used for example in integration tests when one wants to assert authorization code.