### PR TITLE
Add TokenX mock endpoints

### DIFF
--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/auth/JsonWebKeySupport.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/auth/JsonWebKeySupport.kt
@@ -9,16 +9,14 @@ import java.security.interfaces.RSAPublicKey
 
 @Component
 class JsonWebKeySupport(private val jwk: RsaJsonWebKey) {
-    fun jwks() = JwksList(
-        keys = listOf(
-            Jwks(
-                kty = "RSA",
-                alg = "RS256",
-                use = "sig",
-                kid = "1",
-                n = encode((jwk.publicKey as RSAPublicKey).modulus.toByteArray()),
-                e = encode(jwk.getRsaPublicKey().publicExponent.toByteArray())
-            )
+    fun jwks() = listOf(
+        Jwks(
+            kty = "RSA",
+            alg = "RS256",
+            use = "sig",
+            kid = "1",
+            n = encode((jwk.publicKey as RSAPublicKey).modulus.toByteArray()),
+            e = encode(jwk.getRsaPublicKey().publicExponent.toByteArray())
         )
     )
 
@@ -30,8 +28,6 @@ class JsonWebKeySupport(private val jwk: RsaJsonWebKey) {
         val n: String,
         val e: String
     )
-
-    data class JwksList(val keys: List<Jwks>)
 
     fun createRS256Token(string: String?): JsonWebSignature {
         with(JsonWebSignature()) {

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/auth/tokenx/TokenxMock.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/auth/tokenx/TokenxMock.kt
@@ -1,0 +1,80 @@
+package no.nav.pensjon.vtp.auth.tokenx
+
+import io.swagger.annotations.ApiOperation
+import no.nav.pensjon.vtp.auth.*
+import org.jose4j.jwt.JwtClaims
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.web.bind.annotation.*
+import javax.servlet.http.HttpServletRequest
+
+@RestController
+@RequestMapping("/rest/tokenx")
+class TokenxMock(
+    private val jsonWebKeySupport: JsonWebKeySupport
+) {
+    @GetMapping(value = ["/.well-known/oauth-authorization-server"], produces = [APPLICATION_JSON_VALUE])
+    @ApiOperation(value = "TokenX well-known URL", notes = "Mock impl av TokenX well-known URL. ")
+    fun wellKnown(req: HttpServletRequest): WellKnownResponse {
+        val baseUrl = baseUrl(req.serverName, req.serverPort)
+        return WellKnownResponse(
+            issuer = baseUrl,
+            jwks_uri = "$baseUrl/jwks",
+            token_endpoint = "$baseUrl/token",
+        )
+    }
+
+    @GetMapping("/jwks")
+    @ApiOperation(value = "TokenX public key set")
+    fun jwks() = jsonWebKeySupport.jwks()
+
+    @PostMapping("/token")
+    @ApiOperation(value = "Exchange token via tokendings")
+    fun token(
+        req: HttpServletRequest,
+        @RequestParam("grant_type", defaultValue = "urn:ietf:params:oauth:grant-type:token-exchange") grantType: String,
+        @RequestParam("client_assertion_type", defaultValue = "urn:ietf:params:oauth:grant-type:token-exchange") client_assertion_type: String,
+        @RequestParam("client_assertion") client_assertion: String,
+        @RequestParam("subject_token_type", defaultValue = "urn:ietf:params:oauth:token-type:jwt") subject_token_type: String,
+        @RequestParam("subject_token") subject_token: String,
+        @RequestParam("audience") audience: String,
+    ) = TokenResponse(
+        access_token = accessToken(
+            jsonWebKeySupport = jsonWebKeySupport,
+            issuer = baseUrl(req.serverName, req.serverPort),
+            audience = audience
+        )
+    )
+}
+
+private fun accessToken(
+    jsonWebKeySupport: JsonWebKeySupport,
+    issuer: String,
+    audience: String
+) = jsonWebKeySupport.createRS256Token(
+    JwtClaims().apply {
+        setIssuer(issuer)
+        setAudience(audience)
+        setExpirationTimeMinutesInTheFuture(60F)
+        setIssuedAtToNow()
+        setNotBeforeMinutesInThePast(0F)
+    }.toJson()
+).compactSerialization
+
+private fun baseUrl(serverAddress: String, serverPort: Int) = "http://$serverAddress:$serverPort/rest/tokenx"
+
+data class TokenResponse(
+    val access_token: String,
+    val issued_token_type: String = "urn:ietf:params:oauth:token-type:access_token",
+    val token_type: String = "Bearer",
+    val expiresIn: Int = 3600
+)
+
+data class WellKnownResponse(
+    val issuer: String = "temp",
+    val token_endpoint: String,
+    val jwks_uri: String,
+    val grant_types_supported: List<String> = listOf("urn:ietf:params:oauth:grant-type:token-exchange"),
+    val token_endpoint_auth_methods_supported: List<String> = listOf("private_key_jwt"),
+    val token_endpoint_auth_signing_alg_values_supported: List<String> = listOf("RS256"),
+    val subject_types_supported: List<String> = listOf("public"),
+)

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/configuration/WebConfiguration.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/configuration/WebConfiguration.kt
@@ -1,0 +1,13 @@
+package no.nav.pensjon.vtp.configuration
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.filter.ForwardedHeaderFilter
+
+@Configuration
+class WebConfiguration {
+    @Bean
+    fun forwardedHeaderFilter(): ForwardedHeaderFilter? {
+        return ForwardedHeaderFilter()
+    }
+}

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/util/MvcUtils.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/util/MvcUtils.kt
@@ -1,0 +1,12 @@
+package no.nav.pensjon.vtp.util
+
+import org.springframework.http.ResponseEntity.notFound
+import org.springframework.http.ResponseEntity.ok
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URI
+
+fun <T> T?.asResponseEntity() = this
+    ?.let(::ok)
+    ?: notFound().build()
+
+fun URI.withoutQueryParameters() = UriComponentsBuilder.fromUri(this).query(null).build().toUri()

--- a/vtp-pensjon-frontend/src/components/Snitch/PayloadSummary.tsx
+++ b/vtp-pensjon-frontend/src/components/Snitch/PayloadSummary.tsx
@@ -1,4 +1,4 @@
-import { Badge, Card } from "react-bootstrap";
+import {Badge, Card} from "react-bootstrap";
 import React from "react";
 import { Payload } from "./types";
 import PrettyPrintedPayloadBody from "./PrettyPrintedPayloadBody";

--- a/vtp-pensjon-frontend/src/components/Snitch/PrettyPrintedPayloadBody.tsx
+++ b/vtp-pensjon-frontend/src/components/Snitch/PrettyPrintedPayloadBody.tsx
@@ -2,6 +2,8 @@ import { parse as parseContentType } from "content-type";
 import React from "react";
 import xmlFormatter from "xml-formatter";
 import ReactJson from "react-json-view";
+import CopyToClipboard from "react-copy-to-clipboard";
+import {Button} from "react-bootstrap";
 
 function decodeBody(value: string): string {
   return decodeURIComponent(
@@ -52,6 +54,17 @@ function asWwwFormUrlencoded(content: string): JSX.Element {
   );
 }
 
+function CopyToClipboardButton(props: { text: string }): JSX.Element {
+  return <div className="clearfix">
+    <div style={{paddingBottom: "6px"}} className="float-right">
+      <CopyToClipboard text={props.text}>
+        <Button variant="outline-primary" size="sm">
+          Kopier til utklippstavle ⧉
+        </Button>
+      </CopyToClipboard>
+    </div>
+  </div>
+}
 export default function PrettyPrintedPayloadBody(
   props: BodyProps
 ): JSX.Element {
@@ -64,16 +77,28 @@ export default function PrettyPrintedPayloadBody(
     const contentType = parseContentType(props.contentType).type;
     switch (contentType) {
       case "application/json":
-        return <pre>{asJson(decodeBody(content))}</pre>;
+        return <>
+          <CopyToClipboardButton text={decodeBody(content)}/>
+          <pre>{asJson(decodeBody(content))}</pre>
+        </>;
 
       case "application/xml":
-        return <pre>{asXml(decodeBody(content))}</pre>;
+        return <>
+          <CopyToClipboardButton text={decodeBody(content)}/>
+          <pre>{asXml(decodeBody(content))}</pre>
+        </>;
 
       case "text/xml":
-        return <pre>{asXml(decodeBody(content))}</pre>;
+        return <>
+          <CopyToClipboardButton text={decodeBody(content)}/>
+          <pre>{asXml(decodeBody(content))}</pre>
+        </>;
 
       case "text/html":
-        return <pre>{decodeBody(content)}</pre>;
+        return <>
+          <CopyToClipboardButton text={decodeBody(content)}/>
+          <pre>{decodeBody(content)}</pre>
+        </>;
 
       case "application/x-www-form-urlencoded":
         return asWwwFormUrlencoded(decodeBody(content));

--- a/vtp-pensjon-frontend/src/components/Unleash/unleash.tsx
+++ b/vtp-pensjon-frontend/src/components/Unleash/unleash.tsx
@@ -51,7 +51,7 @@ function AddFeatureForm(props: { name: string, enabled: boolean, onNameChange: (
     </Form>
 }
 
-function AddFeatureModal(props: { show: Boolean, onClose: () => void, onAddFeature: (feature: Feature) => void,
+function AddFeatureModal(props: { show: boolean, onClose: () => void, onAddFeature: (feature: Feature) => void,
     name: string, enabled: boolean, onNameChange: (name: string) => void, onEnabledChange: (enabled: boolean) => void
 }) {
     return <Modal


### PR DESCRIPTION
Fungerende utgangspunkt for å kunne validere TokenX tokens. 

To-do:
- Faktisk håndtering av innvekslet `subject_token` som blandt annet skal returnere claims som `pid`.
- Frontend for _Generer token_.