### PR TITLE
Endrer Dockerfile til å hente temurin image. Oppdaterer readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:11 as builder
 ARG JAR_FILE=vtp-pensjon-application/target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:11
 ENV TZ="Europe/Oslo"
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./

--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ Interne henvendelser kan sendes via Slack i kanalen #pensjon-teknisk
 
 === Teknologi som må installeres
 
-* Java 11 (https://adoptopenjdk.net/)
+* Java 11 (https://adoptium.net)
 * Node.js 14 (https://nodejs.org/en/download/)
 * Maven 3.6 (http://maven.apache.org/)
 


### PR DESCRIPTION
Adoptopenjdk gir mystiske JVM feil på m1 mac. Det problemet forekommer ikke med temurin. 
Temurin har jo også tatt over for adoptopenjdk, derfor foreslår jeg at VTP bytter til å bygge med temurin