### PR TITLE
Add scope and audience as parameters to sts tokens

### DIFF
--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/auth/OidcTokenGenerator.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/auth/OidcTokenGenerator.kt
@@ -17,6 +17,7 @@ class OidcTokenGenerator(
         aud: List<String>,
         expiration: NumericDate,
         issuedAt: NumericDate = now(),
+        scope: String? = null,
         additionalClaims: Map<String, Any>
     ): String {
         return jsonWebKeySupport.createRS256Token(
@@ -36,6 +37,8 @@ class OidcTokenGenerator(
                 for ((key, value) in additionalClaims) {
                     setClaim(key, value)
                 }
+
+                scope?.let { setClaim("scope", scope) }
             }.toJson()
         ).compactSerialization
     }

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/util/MvcUtils.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/util/MvcUtils.kt
@@ -1,11 +1,12 @@
 package no.nav.pensjon.vtp.util
 
+import org.springframework.http.ResponseEntity
 import org.springframework.http.ResponseEntity.notFound
 import org.springframework.http.ResponseEntity.ok
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
 
-fun <T> T?.asResponseEntity() = this
+fun <T> T?.asResponseEntity(): ResponseEntity<T> = this
     ?.let(::ok)
     ?: notFound().build()
 

--- a/vtp-pensjon-client/src/main/kotlin/no/nav/pensjon/vtp/client/tokens/TokenFetcher.kt
+++ b/vtp-pensjon-client/src/main/kotlin/no/nav/pensjon/vtp/client/tokens/TokenFetcher.kt
@@ -104,6 +104,8 @@ internal class TokenFetcher(
     fun fetchStsToken(
         issuer: String,
         user: String,
+        scope: String = "openid",
+        audience: List<String>? = null,
     ): AccessTokenResponse = okHttpClient
         .newCall(
             request()
@@ -112,8 +114,8 @@ internal class TokenFetcher(
                     queryParameters = mapOf(
                         "issuer" to issuer,
                         "grant_type" to "client_credentials",
-                        "scope" to "openid"
-                    )
+                        "scope" to scope
+                    ) + (audience?.let { mapOf("audience" to audience.joinToString(",")) } ?: emptyMap())
                 )
                 .basicAuth(username = user, password = "dummy")
                 .build()


### PR DESCRIPTION
Legger til muligheten for å spesifisere audience og scope. Dette trengs for å hente ut tokens tilsvarende de som blir utstedt for nå api gateway oversetter maskinporte- tokens


![Skjermbilde 2022-06-02 kl  08 56 34](https://user-images.githubusercontent.com/5680727/171571248-0cf7a5dd-ecc9-46ad-bf1c-6f4c7871a765.png)
