### PR TITLE
Improve mocking of ldap server

### DIFF
--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/ldap/SnitchInMemoryOperationInterceptor.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/mocks/ldap/SnitchInMemoryOperationInterceptor.kt
@@ -1,0 +1,132 @@
+package no.nav.pensjon.vtp.mocks.ldap
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.unboundid.ldap.listener.interceptor.*
+import no.nav.pensjon.vtp.snitch.Payload
+import no.nav.pensjon.vtp.snitch.RequestResponse
+import no.nav.pensjon.vtp.snitch.SnitchService
+import org.springframework.stereotype.Component
+
+@Component
+class SnitchInMemoryOperationInterceptor(private val snitchService: SnitchService) : InMemoryOperationInterceptor() {
+    private val objectMapper = ObjectMapper()
+
+    override fun processAddResult(result: InMemoryInterceptedAddResult?) {
+        snitchService.save(requestResponse("ad", emptyPayload(), emptyPayload()))
+    }
+
+    override fun processSASLBindResult(result: InMemoryInterceptedSASLBindResult?) {
+        snitchService.save(requestResponse("saslBin", emptyPayload(), emptyPayload()))
+    }
+
+    override fun processCompareResult(result: InMemoryInterceptedCompareResult?) {
+        snitchService.save(requestResponse("compare", emptyPayload(), emptyPayload()))
+    }
+
+    override fun processDeleteResult(result: InMemoryInterceptedDeleteResult?) {
+        snitchService.save(requestResponse("delete", emptyPayload(), emptyPayload()))
+    }
+
+    override fun processExtendedResult(result: InMemoryInterceptedExtendedResult?) {
+        snitchService.save(requestResponse("extended", emptyPayload(), emptyPayload()))
+    }
+
+    override fun processModifyResult(result: InMemoryInterceptedModifyResult?) {
+        snitchService.save(requestResponse("modify", emptyPayload(), emptyPayload()))
+    }
+
+    override fun processModifyDNResult(result: InMemoryInterceptedModifyDNResult?) {
+        snitchService.save(requestResponse("modifyDN", emptyPayload(), emptyPayload()))
+    }
+
+    override fun processSearchRequest(request: InMemoryInterceptedSearchRequest?) {
+        super.processSearchRequest(request)
+    }
+
+    override fun processSearchResult(result: InMemoryInterceptedSearchResult?) {
+        snitchService.save(
+            requestResponse(
+                "search",
+                payload(result?.request?.run {
+                    mapOf(
+                        "attributeList" to attributeList,
+                        "baseDN" to baseDN,
+                        "dereferencePolicy" to dereferencePolicy,
+                        "filter" to filter,
+                        "scope" to scope,
+                        "sizeLimit" to sizeLimit,
+                        "timeLimitSeconds" to timeLimitSeconds,
+                        "controlList" to controlList,
+                        "controls" to controls,
+                    )
+                }),
+                payload(result?.result?.run {
+                    mapOf(
+                        "diagnosticMessage" to diagnosticMessage,
+                        "matchedDN" to matchedDN ,
+                        "responseControls" to responseControls,
+                        "messageID" to messageID,
+                        "referralURLs" to referralURLs,
+                    )
+                }),
+            )
+        )
+    }
+
+    override fun processIntermediateResponse(response: InMemoryInterceptedIntermediateResponse?) {
+        snitchService.save(requestResponse("intermediate", emptyPayload(), emptyPayload()))
+    }
+
+    override fun processSimpleBindResult(result: InMemoryInterceptedSimpleBindResult?) {
+        snitchService.save(
+            requestResponse("bind", payload(
+                result?.request?.run {
+                    mapOf(
+                        "bindDn" to bindDN,
+                        "password" to password
+                    )
+                }), payload(result?.result?.run {
+                mapOf(
+                    "diagnosticMessage" to diagnosticMessage,
+                    "matchedDN" to matchedDN,
+                    "responseControls" to responseControls,
+                    "resultCode" to resultCode,
+                    "referralURLs" to referralURLs,
+                    "matchedDN" to matchedDN,
+                )
+            })
+            )
+        )
+    }
+
+    private fun requestResponse(
+        path: String,
+        request: Payload,
+        responsePayload: Payload
+    ) = RequestResponse(
+        method = "LDAP",
+        path = path,
+        url = "ldap://",
+        status = 0,
+        request = request,
+        response = responsePayload
+    )
+
+    private fun payload(content: Any?) =
+        content?.let { jsonPayload(objectMapper.writeValueAsBytes(it)) } ?: emptyPayload()
+
+    private fun emptyPayload() = Payload(
+        headers = emptyMap(),
+        contentType = null,
+        contentLength = 0,
+        content = null,
+    )
+
+    private fun jsonPayload(content: ByteArray) = Payload(
+        headers = emptyMap(),
+        contentType = "application/json",
+        contentLength = content.size,
+        content = content,
+    )
+}
+

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/snitch/RequestResponse.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/snitch/RequestResponse.kt
@@ -9,17 +9,17 @@ import java.util.UUID.randomUUID
 data class RequestResponse(
     @Id
     val id: String = randomUUID().toString(),
-    val timestamp: LocalDateTime,
+    val timestamp: LocalDateTime = LocalDateTime.now(),
     val method: String,
     val path: String,
-    val queryString: String?,
+    val queryString: String? = null,
     val url: String,
     val status: Int,
-    val handler: String?,
-    val handlerClass: String?,
-    val handlerMethod: String?,
-    val exception: String?,
-    val stackTrace: String?,
+    val handler: String? = null,
+    val handlerClass: String? = null,
+    val handlerMethod: String? = null,
+    val exception: String? = null,
+    val stackTrace: String? = null,
 
     val request: Payload,
 

--- a/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/snitch/SnitchFilter.kt
+++ b/vtp-pensjon-application/src/main/kotlin/no/nav/pensjon/vtp/snitch/SnitchFilter.kt
@@ -81,7 +81,6 @@ class SnitchFilter(
         requestWrapper: ContentCachingRequestWrapper,
         responseWrapper: ContentCachingResponseWrapper
     ) = RequestResponse(
-        timestamp = now(),
         path = URL(requestWrapper.requestURL.toString()).path,
         queryString = requestWrapper.queryString,
         url = fullURL(requestWrapper),

--- a/vtp-pensjon-application/src/main/resources/basedata/ldap_setup.ldif
+++ b/vtp-pensjon-application/src/main/resources/basedata/ldap_setup.ldif
@@ -14,18 +14,37 @@ objectclass: organization
 
 dn: OU=BusinessUnits,DC=test,DC=local
 changetype: add
-dc: BusinessUnits
+ou: BusinessUnits
 objectClass: organizationalUnit
 objectClass: top
 
 dn: OU=NAV,OU=BusinessUnits,DC=test,DC=local
 changetype: add
-dc: NAV
+ou: NAV
 objectClass: organizationalUnit
 objectClass: top
 
 dn: OU=Users,OU=NAV,OU=BusinessUnits,DC=test,DC=local
 changetype: add
-dc: Users
+ou: Users
 objectClass: organizationalUnit
 objectClass: top
+
+dn: OU=Groups,OU=NAV,OU=BusinessUnits,DC=test,DC=local
+changetype: add
+ou: Groups
+objectClass: organizationalUnit
+objectClass: top
+
+dn: OU=AccountGroups,OU=Groups,OU=NAV,OU=BusinessUnits,DC=test,DC=local
+changetype: add
+ou: AccountGroups
+objectClass: organizationalUnit
+objectClass: top
+
+dn: CN=0000-GA-PENSJON-PIP,OU=AccountGroups,OU=Groups,OU=NAV,OU=BusinessUnits,DC=test,DC=local
+changetype: add
+cn: 0000-GA-PENSJON-PIP
+objectclass: top
+objectclass: groupofnames
+member: CN=pensjon-pip,OU=Users,OU=NAV,OU=BusinessUnits,DC=test,DC=local

--- a/vtp-pensjon-application/src/main/resources/basedata/navansatte.json
+++ b/vtp-pensjon-application/src/main/resources/basedata/navansatte.json
@@ -133,5 +133,18 @@
       "0000-GA-PENSJON_UTLAND",
       "0000-GA-PENSJON_UTVIDET"
     ]
+  },
+  {
+    "cn": "pensjon-pip",
+    "givenname": "Pensjon PIP",
+    "sn": "PIP",
+    "displayName": "Pensjon PIP",
+    "email": "pensjon.pip@example.com",
+    "enheter": [
+      "1234"
+    ],
+    "groups": [
+      "0000-GA-PENSJON-PIP"
+    ]
   }
 ]


### PR DESCRIPTION
- Add to Snitch
- Fix some errors in ldif file
- Add group used by abac/saf for querying Pesys

Har ikke så veldig god oversikt over LDAP, men det her funker bedre enn det vi har 😂. Får til å teste Basic Auth i Pesys når Pesys er satt opp med LDAP. Funker dessverre ikke når Pesys er konfigurert til å bruke Active Directory.

Jeg har brukt det til å teste overgang til Spring Security hvor jeg har kommentert inn og ut bruk av LDAP / Active Directory. Har trengt dette for å se at det funger med både Basic auth og JWT'er.

Visningen i Snitchen er litt corny siden dette ikke er HTTP-kall (se skjermbilde). Kunne sikkert lagt til en protokollkolonne, og så lagt bind / search på method. Tenker vi eventuelt kan ta dette senere. Håper egentlig at vi blir kvitt bruk av LDAP i `#po-pensjon`
<img width="1648" alt="Skjermbilde 2022-06-19 kl  14 32 25" src="https://user-images.githubusercontent.com/5680727/174481107-38c5a3c3-0d1b-49b7-a3b4-2f74555d8d87.png">

